### PR TITLE
Fixes global leak

### DIFF
--- a/bases.js
+++ b/bases.js
@@ -79,7 +79,7 @@ bases.KNOWN_ALPHABETS[58] = bases.KNOWN_ALPHABETS[62].replace(/[0OlI]/g, '');
 bases.KNOWN_ALPHABETS[32] = bases.NUMERALS + bases.LETTERS_UPPERCASE.replace(/[ILOU]/g, '');
 
 // Closure helper for convenience aliases like bases.toBase36():
-makeAlias = function (base, alphabet) {
+var makeAlias = function (base, alphabet) {
     bases['toBase' + base] = function (num) {
         return bases.toAlphabet(num, alphabet);
     };


### PR DESCRIPTION
'makeAlias' was initialized without a "var" declaration so it's scope is the global scope. Any other module using a "makeAlias" variable could break things.

I found the problem thanks to the mocha's built-in global leak detector.
